### PR TITLE
✨ wetty 기반 web ssh 추가

### DIFF
--- a/backend/src/main/java/com/devlatte/devroom/k8s/api/user/ClassApi.java
+++ b/backend/src/main/java/com/devlatte/devroom/k8s/api/user/ClassApi.java
@@ -141,6 +141,12 @@ public class ClassApi extends K8sApiBase {
             labels.put("connection", "ssh");
         }
 
+        // web ssh (wetty) 용 포트개방
+        if (options.containsKey("web_ssh") && options.get("web_ssh").equals("yes")){
+            inPort = "3000";
+            labels.put("connection", "web_ssh");
+        }
+
         if (!labels.containsKey("connection")){
             labels.put("connection", "none");
         }
@@ -172,6 +178,13 @@ public class ClassApi extends K8sApiBase {
         // ssh 설치용 스크립트
         if (options.containsKey("ssh") && options.get("ssh").equals("yes"))
             data.put("01_install_ssh.sh",FreemarkerTemplate.convert("/scripts/", "01_install_ssh.sh", template).replaceAll("\\r", ""));
+
+        // wetty 설치용 스크립트
+        if (options.containsKey("web_ssh") && options.get("web_ssh").equals("yes")) {
+            data.put("01_install_ssh.sh",FreemarkerTemplate.convert("/scripts/", "01_install_ssh.sh", template).replaceAll("\\r", ""));
+            data.put("03_install_wetty.sh",FreemarkerTemplate.convert("/scripts/", "03_install_wetty.sh", template).replaceAll("\\r", ""));
+        }
+
 
         // vscode 설치용 스크립트
         if (options.containsKey("vscode") && options.get("vscode").equals("yes"))

--- a/backend/src/main/resources/scripts/03_install_wetty.sh
+++ b/backend/src/main/resources/scripts/03_install_wetty.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+student_id=${student}
+class_id=${class}
+username="$student_id"-"$class_id"
+
+sudo apt update -qq
+sudo apt install -qq -y build-essential curl software-properties-common openssh-client
+
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt update -qq
+sudo apt install -qq -y python3.11 python3.11-venv python3.11-distutils
+
+echo "Configuring Python 3.11 alternatives..."
+sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
+# Check if Python 3.11 is available and set it as default
+PYTHON_PATH=$(which python3.11)
+if [ -n "$PYTHON_PATH" ]; then
+    echo "Setting Python 3.11 as the default Python 3...=============================================="
+    sudo update-alternatives --set python3 /usr/bin/python3.11
+else
+    echo "Python 3.11 not found in alternatives. Please check installation.==========================="
+    exit 1
+fi
+
+echo "Exporting Python environment variable..."
+echo 'export PYTHON=/usr/bin/python3.11' >> ~/.bashrc
+source ~/.bashrc
+
+# WeTTY 설치 및 실행
+su - $username <<EOF
+python3 --version
+
+# 필수 패키지 및 WeTTY 설치
+curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash && source ~/.profile
+source ~/.nvm/nvm.sh
+nvm install 20
+node -v
+
+# SSL 설정
+#mkdir -p ~/.ssl
+#openssl req -x509 -nodes -days 1095 -newkey ec:<(openssl ecparam -name secp384r1) -subj "/C=GB/ST=None/L=None/O=None/OU=None/CN=None" -out ~/.ssl/wetty.crt -keyout ~/.ssl/wetty.key
+#chmod 700 ~/.ssl
+#chmod 644 ~/.ssl/wetty.crt
+#chmod 600 ~/.ssl/wetty.key
+
+# SSH 키 설정
+#mkdir -p ~/.ssh
+#ssh-keygen -q -C "wetty-keyfile" -t ed25519 -N '' -f ~/.ssh/wetty 2>/dev/null <<< y >/dev/null
+#cat ~/.ssh/wetty.pub >> ~/.ssh/authorized_keys
+#chmod 700 ~/.ssh
+#chmod 644 ~/.ssh/authorized_keys
+#chmod 600 ~/.ssh/wetty
+
+# WeTTY 설치 및 실행
+mkdir -p ~/bin && source ~/.profile
+npm -g i wetty@2.5.0
+
+wetty -h
+
+# 접속 URL 출력
+echo https://$(curl -s4 icanhazip.com):3000
+
+# WeTTY 시작
+wetty --host 0.0.0.0 --port 3000 --title $username --base / --ssh-host localhost --ssh-user $username --ssh-port 22 --ssh-auth password
+
+EOF

--- a/backend/src/main/resources/scripts/ubuntu_command.sh
+++ b/backend/src/main/resources/scripts/ubuntu_command.sh
@@ -1,4 +1,4 @@
 echo "init student container"
 cp -r /app/config /script
 chmod +x /script/ubuntu_init.sh
-/script/ubuntu_init.sh >> /script/log
+/script/ubuntu_init.sh >> /script/log 2>&1


### PR DESCRIPTION
WeTTY를 통해 웹 브라우저 기반의 ssh 연결 기능을 추가했습니다. API 요청시 다음과 같은 양식으로 사용할 수 있습니다.

{{api_url}}/class/2019312218/create
```json
{
    "className": "wetty-test",
    "studentIds": [ "2019312219" ],
    "options": { "web_ssh": "yes" },
    "customScript": []
}
```